### PR TITLE
Added cors to api server

### DIFF
--- a/main-app/api/package-lock.json
+++ b/main-app/api/package-lock.json
@@ -1529,6 +1529,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -5118,8 +5127,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",

--- a/main-app/api/package.json
+++ b/main-app/api/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.18.3",
+    "cors": "^2.8.5",
     "express": "^4.16.4",
     "knex": "^0.16.2",
     "pg": "^7.7.1"

--- a/main-app/api/server/app.js
+++ b/main-app/api/server/app.js
@@ -1,8 +1,10 @@
 const express = require('express');
+const cors = require('cors');
 const bodyParser = require('body-parser');
 const path = require('path');
 
 const app = express();
+app.use(cors());
 
 app.use(bodyParser.json());
 app.use(express.static(path.join(__dirname, '../node_modules')));


### PR DESCRIPTION
This package should resolve the cors problem for the feature/user-profile-page

To use this in the feature/user-profile-page branch, you'll need to update
`client/src/get_uri.js` to add `http://` to the endpoint.

Should look like:
`export const API_ENDPOINT = 'http://localhost:4000';`