### PR TITLE
Version bump to squash github complaint

### DIFF
--- a/main-app/client/package-lock.json
+++ b/main-app/client/package-lock.json
@@ -7697,7 +7697,7 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "optional": true,
           "requires": {


### PR DESCRIPTION
We don't use tar, but hey let's bump to the same version we have in the api's package-lock.json