### PR TITLE
Fix for spam in the docker messages 

### DIFF
--- a/main-app/docker-compose.yml
+++ b/main-app/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:10.6
     container_name: heart_postgres
     healthcheck:
-      test: pg_isready -h 127.0.0.1
+      test: pg_isready -U postgres -h 127.0.0.1
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
The health check was using 'root' instead of 'postgres' which created spam in the docker console messages.

Small fix to set the user