### PR TITLE
create NavBar component that wraps MUI-AppBar

### DIFF
--- a/main-app/client/src/App.js
+++ b/main-app/client/src/App.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom'
 import jwtDecode from 'jwt-decode'
 import { withStyles } from '@material-ui/core/styles'
-import NavBar from './components/Navbar/navbar'
+import NavBar from './components/NavBar'
 import ParticipantProfile from './components/Participant/Profile'
 import LoginPage from './components/Authorization/loginPage'
 import { UserAuth } from './utilities/auth'
@@ -12,6 +12,8 @@ import { NoMatch } from './routes/NoMatch'
 import { PrivateRoute } from '../src/routes/privateRoute'
 import withRoot from './withRoot'
 import ParticipantsList from './components/ParticipantsList/ParticipantsList'
+
+import { PATHS } from './routes'
 
 const UserContext = React.createContext({
   user: null,
@@ -23,8 +25,8 @@ const UserProvider = UserContext.Provider
 const styles = theme => ({
   root: {
     flexBasis: 1,
-  }
-});
+  },
+})
 
 class App extends Component {
   state = {
@@ -101,7 +103,7 @@ class App extends Component {
               <main>
                 <Switch>
                   <Route
-                    path="/login"
+                    path={PATHS.LOGIN}
                     render={({ location }) => (
                       <LoginPage
                         location={location}
@@ -111,16 +113,16 @@ class App extends Component {
                   />
                   <PrivateRoute
                     exact={true}
-                    path="/"
+                    path={PATHS.PARTICIPANTS}
                     component={ParticipantsList}
                   />
                   <PrivateRoute
                     exact={true}
-                    path="/participants/:id/"
+                    path={PATHS.PARTICIPANT}
                     component={ParticipantProfile}
                   />
                   {/* hold off on making this route privat */}
-                  <Route exact={true} path="/form" component={Intake} />
+                  <Route exact={true} path={PATHS.INTAKE} component={Intake} />
                   <Redirect from="/" to="/login" />
                   <Route component={NoMatch} />
                 </Switch>

--- a/main-app/client/src/components/NavBar/index.jsx
+++ b/main-app/client/src/components/NavBar/index.jsx
@@ -1,0 +1,108 @@
+import React from 'react'
+
+import { UserAuth } from '../../utilities/auth'
+
+import { PATHS } from '../../routes'
+import { withRouter } from 'react-router-dom'
+import { makeStyles } from '@material-ui/core/styles'
+
+import AppBar from '@material-ui/core/AppBar'
+import Toolbar from '@material-ui/core/Toolbar'
+import Button from '@material-ui/core/Button'
+
+const useStyles = makeStyles(theme => ({
+  ToolBar: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    [theme.breakpoints.down('xs')]: {
+      display: 'block',
+    },
+  },
+  LeftContent: {
+    marginLeft: '9%',
+    [theme.breakpoints.down('xs')]: {
+      margin: 'auto',
+    },
+  },
+  RightContent: {
+    marginRight: '9%',
+    [theme.breakpoints.down('xs')]: {
+      margin: 'auto',
+    },
+  },
+  Button: {
+    width: 'auto',
+    margin: '5px',
+    [theme.breakpoints.down('xs')]: {
+      width: '100%',
+    },
+  },
+}))
+
+const NavBar = ({ onLogout }) => {
+  const classes = useStyles()
+
+  const buttonWithRoute = ({ name, onClick, path }) => {
+    const handleClick = history => () => {
+      if (onClick) {
+        onClick()
+      }
+
+      history.push(path)
+    }
+
+    return withRouter(({ history }) => (
+      <Button className={classes.Button} onClick={handleClick(history)}>
+        {name}
+      </Button>
+    ))
+  }
+  const HomeButton = buttonWithRoute({
+    name: 'Home',
+    path: PATHS.PARTICIPANTS,
+  })
+  const IntakeFormButton = buttonWithRoute({
+    name: 'Intake Form',
+    path: PATHS.INTAKE,
+  })
+  const LogOutButton = buttonWithRoute({
+    name: 'Log Out',
+    onClick: onLogout,
+    path: PATHS.LOGIN,
+  })
+  const LogInButton = buttonWithRoute({
+    name: 'Login',
+    path: PATHS.LOGIN,
+  })
+
+  return (
+    <div>
+      <AppBar color="default" position="sticky">
+        <Toolbar className={classes.ToolBar}>
+          {UserAuth.loggedIn() ? (
+            <>
+              <div className={classes.LeftContent}>
+                <HomeButton />
+                <IntakeFormButton />
+              </div>
+              <div className={classes.RightContent}>
+                <LogOutButton />
+              </div>
+            </>
+          ) : (
+            <>
+              <div className={classes.LeftContent}>
+                <p>Heart</p>
+              </div>
+              <div className={classes.RightContent}>
+                <LogInButton />
+              </div>
+            </>
+          )}
+        </Toolbar>
+      </AppBar>
+    </div>
+  )
+}
+
+export default NavBar

--- a/main-app/client/src/routes/index.js
+++ b/main-app/client/src/routes/index.js
@@ -1,0 +1,13 @@
+import Intake from '../components/Form/Intake'
+import LoginPage from '../components/Authorization/loginPage'
+import ParticipantList from '../components/ParticipantsList/ParticipantsList'
+import ParticipantProfile from '../components/Participant/Profile'
+
+export const PATHS = {
+  INTAKE: '/form',
+  LOGIN: '/login',
+  PARTICIPANT: '/participants/:id',
+  PARTICIPANTS: '/',
+}
+
+export default { PATHS }


### PR DESCRIPTION
For [issue 147](#147).

- [x] Convert to Material UI Appbar
- [x] Make the bar stick to top
- [x] Pull styles and add them to a useStyles hook

#### `NavBar` Responsiveness
The current style is pretty close to the mockup. For smaller screen sizes,
the nav buttons will be stacked on top of each other and take the full width. Uses Material UI's [breakpoints](https://material-ui.com/customization/breakpoints/) for handling dynamic resizing.

#### Follow Ups
I want to remove the previous `Navbar` component, but want to keep it around for now so we can references the css.