### PR TITLE
fix bug to show proper names of obligations

### DIFF
--- a/main-app/client/src/components/Form/shared/FormSummary.js
+++ b/main-app/client/src/components/Form/shared/FormSummary.js
@@ -10,11 +10,10 @@ const useStyles = makeStyles(theme => ({
     margin: '18px auto',
     textTransform: 'uppercase',
     letterSpacing: '1px',
-  }
+  },
 }))
 
-
-const renderValue = (value, index) => {
+const renderValue = (value, index, obligationGroups) => {
   if (value === 'Is there an urgent rush?') {
     return (
       <div key={index} style={{ color: 'red' }}>
@@ -23,16 +22,57 @@ const renderValue = (value, index) => {
       </div>
     )
   } else {
-    return <div key={index}> {value} ✅</div>
+    return (
+      <div key={index}>
+        {' '}
+        {findLabel(value, switchObligation(value), obligationGroups)} ✅
+      </div>
+    )
   }
 }
 
-export const FormSummary = ({ values, title }) => {
+const switchObligation = valueString => {
+  const valueStringSplit = valueString.split('_')
+  const resourceGroup = valueStringSplit[0]
+  switch (resourceGroup) {
+    case 'health':
+      return 0
+    case 'housing':
+      return 1
+    case 'government':
+      return 2
+    case 'hygiene':
+      return 3
+    case 'communication':
+      return 4
+    case 'legal':
+      return 5
+    case 'employment':
+      return 6
+    case 'family':
+      return 7
+    default:
+      console.log('no such resource group')
+  }
+}
+
+const findLabel = (value, groupNumber, obligationGroups) => {
+  const obligation = obligationGroups[groupNumber].obligation.find(
+    obligation => {
+      return obligation.name === value
+    }
+  )
+  return obligation.label
+}
+
+export const FormSummary = ({ values, title, obligationGroups }) => {
   const classes = useStyles()
   return (
     <div className="form-summary">
       <div className={classes.formGroupTitle}>{title}</div>
-      {values.map((value, index) => renderValue(value, index))}
+      {values.map((value, index) =>
+        renderValue(value, index, obligationGroups)
+      )}
     </div>
   )
 }

--- a/main-app/client/src/components/Intake/OnsiteObligationsFormGroup.js
+++ b/main-app/client/src/components/Intake/OnsiteObligationsFormGroup.js
@@ -197,6 +197,7 @@ const OnsiteObligationsFormGroup = props => {
         renderObligations(index, obligationGroups, props, classes)
       )}
       <FormSummary
+        obligationGroups={obligationGroups}
         values={confirmedPrograms(props.values)}
         title="Programs Participated In:"
       />


### PR DESCRIPTION
Use a switch statement as a bandaid to show proper obligation names. Not dynamic, but will work for now.